### PR TITLE
48 observations store

### DIFF
--- a/src/components/Datastream/DatastreamTable.vue
+++ b/src/components/Datastream/DatastreamTable.vue
@@ -58,10 +58,10 @@
     <template v-slot:item.last_observation="{ item }">
       <div v-if="mostRecentObs[item.raw.id]">
         <v-row>
-          {{ formatDate(mostRecentObs[item.raw.id].date) }}
+          {{ formatDate(mostRecentObs[item.raw.id][0]) }}
         </v-row>
         <v-row>
-          {{ mostRecentObs[item.raw.id].value }}&nbsp;
+          {{ mostRecentObs[item.raw.id][1] }}&nbsp;
           {{ getUnitAttrById(item.raw.unitId) }}
         </v-row>
       </div>

--- a/src/components/Datastream/FocusContextPlot.vue
+++ b/src/components/Datastream/FocusContextPlot.vue
@@ -33,7 +33,7 @@ import { useDatastream } from '@/composables/useDatastream'
 import { useThing } from '@/composables/useThing'
 import { focus, context } from '@/utils/FocusContextPlot'
 import { useObservationStore } from '@/store/observations'
-import { DataArray, DataPoint } from '@/types'
+import { DataArray } from '@/types'
 import { usePrimaryOwnerData } from '@/composables/usePrimaryOwnerData'
 
 const obsStore = useObservationStore()
@@ -70,12 +70,11 @@ let focusChart = ref<any>(null)
 let contextChart = ref<any>(null)
 
 function drawPlot(dataArray: DataArray) {
-  const data = dataArray.map((item: DataPoint) => {
-    return {
-      date: new Date(item.date),
-      value: item.value,
-    }
-  })
+  // Observable Plot expects an array of objects so convert
+  const data = dataArray.map(([dateString, value]) => ({
+    date: new Date(dateString),
+    value,
+  }))
 
   if (focusChart.value) {
     const unitSymbol = datastream.value.unitId
@@ -93,7 +92,7 @@ function drawPlot(dataArray: DataArray) {
     focusChart.value.appendChild(focusSVG)
   }
   if (contextChart.value) {
-    const contextSVG = context(data, 1000)
+    const contextSVG = context(data)
     contextChart.value.innerHTML = ''
     contextChart.value.appendChild(contextSVG)
   }

--- a/src/components/Datastream/FocusContextPlot.vue
+++ b/src/components/Datastream/FocusContextPlot.vue
@@ -13,6 +13,16 @@
     <v-card-text>
       <div ref="focusChart"></div>
       <div ref="contextChart"></div>
+      <v-progress-linear
+        v-if="
+          obsStore.observations[datastreamId] &&
+          obsStore.observations[datastreamId].loading
+        "
+        color="primary"
+        indeterminate
+        :height="25"
+        >Loading...</v-progress-linear
+      >
     </v-card-text>
 
     <v-card-actions class="my-3 d-flex justify-center">

--- a/src/components/Datastream/FocusContextPlot.vue
+++ b/src/components/Datastream/FocusContextPlot.vue
@@ -110,7 +110,7 @@ async function fetchDataForPeriod(hours: number) {
       datastream.value.phenomenonBeginTime,
       datastream.value.phenomenonEndTime
     )
-  drawPlot(obsStore.observations[datastream.value.id])
+  drawPlot(obsStore.observations[datastream.value.id].dataArray)
 }
 
 onMounted(async () => {
@@ -124,6 +124,6 @@ onMounted(async () => {
       datastream.value.phenomenonBeginTime,
       datastream.value.phenomenonEndTime
     )
-  drawPlot(obsStore.observations[datastream.value.id])
+  drawPlot(obsStore.observations[datastream.value.id].dataArray)
 })
 </script>

--- a/src/components/Sparkline.vue
+++ b/src/components/Sparkline.vue
@@ -7,7 +7,7 @@ import { ref, onMounted } from 'vue'
 import * as Plot from '@observablehq/plot'
 import * as d3 from 'd3'
 import { PropType } from 'vue'
-import { DataArray, DataPoint } from '@/types'
+import { DataArray } from '@/types'
 
 const props = defineProps({
   observations: {
@@ -26,10 +26,10 @@ function drawChart() {
     ? { line: '#9E9E9E', fill: '#F5F5F5' } // Grey and grey-lighten-4
     : { line: '#4CAF50', fill: '#E8F5E9' } // Green and green-lighten-5
 
-  const observations = props.observations.map((item: DataPoint) => {
+  const observations = props.observations.map((item: [string, number]) => {
     return {
-      date: new Date(item.date),
-      value: item.value,
+      date: new Date(item[0]),
+      value: item[1],
     }
   })
 

--- a/src/composables/useVisibleDatastreams.ts
+++ b/src/composables/useVisibleDatastreams.ts
@@ -1,13 +1,11 @@
 import { computed, onMounted } from 'vue'
 import { useDatastreamStore } from '@/store/datastreams'
 import { useThingOwnership } from './useThingOwnership'
-import { useObservationStore } from '@/store/observations'
 import { useObservationsLast72Hours } from '@/store/observations72Hours'
 
 export function useVisibleDatastreams(thingId: string) {
   const { isOwner } = useThingOwnership(thingId)
   const datastreamStore = useDatastreamStore()
-  const obsStore = useObservationStore()
   const obs72HourStore = useObservationsLast72Hours()
 
   const visibleDatastreams = computed(() => {
@@ -35,7 +33,7 @@ export function useVisibleDatastreams(thingId: string) {
   onMounted(async () => {
     // if (datastreamStore.datastreams[thingId]) return
     await datastreamStore.fetchDatastreamsByThingId(thingId)
-    await obsStore.fetchObservationsBulk(visibleDatastreams.value, 72)
+    await obs72HourStore.fetchObservationsBulk(visibleDatastreams.value)
   })
 
   return { visibleDatastreams, observations, mostRecentObs }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -89,6 +89,12 @@ export const ENDPOINTS = {
     DATASTREAMS: {
       OBSERVATIONS: (id: string, timestamp: string) =>
         `${SENSORTHINGS_BASE}/Datastreams(${id})/Observations?$resultFormat=dataArray&$filter=phenomenonTime%20ge%20${timestamp}&$top=1000`,
+      OBSERVATIONS_BETWEEN_DATES: (
+        id: string,
+        startTime: string,
+        endTime: string
+      ) =>
+        `${SENSORTHINGS_BASE}/Datastreams(${id})/Observations?$resultFormat=dataArray&$filter=phenomenonTime%20ge%20${startTime}%20and%20phenomenonTime%20lt%20${endTime}&$top=1000`,
     },
   },
 }

--- a/src/store/observations.ts
+++ b/src/store/observations.ts
@@ -1,8 +1,7 @@
 import { defineStore } from 'pinia'
-import { api } from '@/utils/api/apiMethods'
-import { ENDPOINTS } from '@/constants'
-import { DataArray, Datastream, ObservationRecord } from '@/types'
-import { useObservationsLast72Hours } from '@/store/observations72Hours'
+import { ObservationRecord } from '@/types'
+import { fetchObservations } from '@/utils/observationsUtils'
+import { DataArray } from '@/types'
 
 export const useObservationStore = defineStore('observations', {
   state: () => ({
@@ -10,108 +9,42 @@ export const useObservationStore = defineStore('observations', {
   }),
   persist: false,
   actions: {
-    async fetchObservations(
-      id: string,
-      hoursBefore: number,
-      beginTime: string,
-      endTime: string
-    ) {
-      const last72HoursStore = useObservationsLast72Hours()
-
-      try {
-        // Check if this.observations[id] exists, if not, initialize it
-        if (!this.observations[id]) {
-          this.observations[id] = {
-            dataArray: [],
-            beginTime: '',
-            endTime: '',
+    updateObservations(id: string, fetchedData: DataArray, beginTime: string) {
+      this.$patch({
+        observations: {
+          ...this.observations,
+          [id]: {
+            dataArray: fetchedData,
+            beginTime: beginTime,
             loading: false,
-          }
-        }
-
-        // If we have cached data, just set this store and return
-        if (hoursBefore == 72 && last72HoursStore.observations[id]) {
-          this.observations[id].dataArray = last72HoursStore.observations[id]
-          last72HoursStore.loaded[id] = true
-          return
-        }
-
-        // If the requested time frame is bigger than the data we have, start at the first data point
-        let startTime = beginTime
-        if (hoursBefore > 0) {
-          const calcStart = this.subtractHours(endTime, hoursBefore)
-          if (new Date(calcStart) > new Date(beginTime)) startTime = calcStart
-        }
-
-        // Keep calling paginated data and combine
-        let allData: DataArray = []
-        let nextLink = ENDPOINTS.SENSORTHINGS.DATASTREAMS.OBSERVATIONS(
-          id,
-          startTime
-        )
-
-        while (nextLink) {
-          const data = await api.fetch(nextLink)
-          if (data.value && data.value[0] && data.value[0].dataArray) {
-            allData = allData.concat(data.value[0].dataArray)
-          }
-          nextLink = data['@iot.nextLink'] || null
-        }
-
-        // Update 72Hours Store to match
-        const end = new Date(endTime)
-        const start72H = new Date(end.getTime() - 72 * 3600000)
-        const last72Hours = allData.filter(
-          (obs: [string, number]) => new Date(obs[0]) >= start72H
-        )
-
-        if (last72Hours && last72Hours.length > 0) {
-          last72HoursStore.setObservations(id, last72Hours)
-          last72HoursStore.setMostRecentObs(id, allData)
-        }
-
-        // Update store
-        if (!allData || !allData.length) return
-
-        this.$patch({
-          observations: {
-            ...this.observations,
-            [id]: {
-              dataArray: allData,
-              beginTime: beginTime,
-              endTime: endTime,
-              loading: false,
-            },
           },
-        })
-      } catch (error) {
-        console.error('Error fetching observations from DB.', error)
-      } finally {
-        last72HoursStore.loaded[id] = true
+        },
+      })
+    },
+    async getObservationsSince(id: string, beginTime: string) {
+      if (!this.observations[id]) {
+        const fetchedData = await fetchObservations(id, beginTime)
+        this.updateObservations(id, fetchedData, beginTime)
+        return fetchedData
       }
-    },
-    async fetchObservationsBulk(datastreams: Datastream[], hours: number) {
-      const last72HoursStore = useObservationsLast72Hours()
-      const observationPromises = datastreams
-        .map((ds) => {
-          if (ds.phenomenonEndTime && ds.phenomenonBeginTime) {
-            return this.fetchObservations(
-              ds.id,
-              hours,
-              ds.phenomenonBeginTime,
-              ds.phenomenonEndTime
-            )
-          } else {
-            last72HoursStore.loaded[ds.id] = true
-          }
+
+      const storedBeginTime = this.observations[id].beginTime
+      const storedBeginDate = new Date(storedBeginTime).getTime()
+      const beginDate = new Date(beginTime).getTime()
+
+      if (beginDate === storedBeginDate) {
+        return this.observations[id].dataArray
+      } else if (beginDate > storedBeginDate) {
+        return this.observations[id].dataArray.filter(([dateString, _]) => {
+          return beginDate < new Date(dateString).getTime()
         })
-        .filter(Boolean)
-      await Promise.all(observationPromises)
-    },
-    subtractHours(timestamp: string, hours: number): string {
-      const date = new Date(timestamp)
-      date.setHours(date.getHours() - hours)
-      return date.toISOString()
+      }
+
+      const newData = await fetchObservations(id, beginTime, storedBeginTime)
+      const aggregatedData = [...newData, ...this.observations[id].dataArray]
+      this.updateObservations(id, aggregatedData, beginTime)
+
+      return this.observations[id].dataArray
     },
   },
 })

--- a/src/store/observations.ts
+++ b/src/store/observations.ts
@@ -23,18 +23,23 @@ export const useObservationStore = defineStore('observations', {
     },
     async getObservationsSince(id: string, beginTime: string) {
       if (!this.observations[id]) {
+        this.observations[id] = new ObservationRecord()
+        this.observations[id].loading = true
         const fetchedData = await fetchObservations(id, beginTime)
         this.updateObservations(id, fetchedData, beginTime)
         return fetchedData
       }
 
+      this.observations[id].loading = true
       const storedBeginTime = this.observations[id].beginTime
       const storedBeginDate = new Date(storedBeginTime).getTime()
       const beginDate = new Date(beginTime).getTime()
 
       if (beginDate === storedBeginDate) {
+        this.observations[id].loading = false
         return this.observations[id].dataArray
       } else if (beginDate > storedBeginDate) {
+        this.observations[id].loading = false
         return this.observations[id].dataArray.filter(([dateString, _]) => {
           return beginDate < new Date(dateString).getTime()
         })

--- a/src/store/observations72Hours.ts
+++ b/src/store/observations72Hours.ts
@@ -1,19 +1,18 @@
 import { defineStore } from 'pinia'
-import { DataArray, DataPoint } from '@/types'
+import { DataArray } from '@/types'
 
 export const useObservationsLast72Hours = defineStore(
   'observationsLast72Hours',
   {
     state: () => ({
       observations: {} as Record<string, DataArray>,
-      mostRecentObs: {} as Record<string, DataPoint>,
+      mostRecentObs: {} as Record<string, [string, number]>,
       loaded: {} as Record<string, Boolean>,
     }),
     actions: {
       setObservations(id: string, data: DataArray) {
-        const clonedData = JSON.parse(JSON.stringify(data))
         this.$patch({
-          observations: { ...this.observations, [id]: clonedData },
+          observations: { ...this.observations, [id]: data },
           loaded: { ...this.loaded, [id]: true },
         })
       },

--- a/src/store/observations72Hours.ts
+++ b/src/store/observations72Hours.ts
@@ -1,5 +1,9 @@
 import { defineStore } from 'pinia'
-import { DataArray } from '@/types'
+import { DataArray, Datastream } from '@/types'
+import {
+  fetchObservations,
+  calculateEffectiveStartTime,
+} from '@/utils/observationsUtils'
 
 export const useObservationsLast72Hours = defineStore(
   'observationsLast72Hours',
@@ -10,17 +14,48 @@ export const useObservationsLast72Hours = defineStore(
       loaded: {} as Record<string, Boolean>,
     }),
     actions: {
-      setObservations(id: string, data: DataArray) {
+      async getObservationsSince(id: string, startTime: string) {
+        try {
+          if (this.observations[id]) {
+            this.loaded[id] = true
+            return
+          }
+
+          let allData: DataArray = await fetchObservations(id, startTime)
+          if (!allData || !allData.length) return
+
+          this.updateObservations(id, allData)
+        } catch (error) {
+          console.error('Error fetching observations from DB.', error)
+        } finally {
+          this.loaded[id] = true
+        }
+      },
+      updateObservations(id: string, data: DataArray) {
+        const mostRecent = data[data.length - 1]
         this.$patch({
           observations: { ...this.observations, [id]: data },
+          mostRecentObs: { ...this.mostRecentObs, [id]: mostRecent },
           loaded: { ...this.loaded, [id]: true },
         })
       },
-      setMostRecentObs(id: string, obs: DataArray) {
-        const mostRecent = obs[obs.length - 1]
-        this.$patch({
-          mostRecentObs: { ...this.mostRecentObs, [id]: mostRecent },
-        })
+      async fetchObservationsBulk(datastreams: Datastream[]) {
+        const last72HoursStore = useObservationsLast72Hours()
+        const observationPromises = datastreams
+          .map((ds) => {
+            if (ds.phenomenonEndTime && ds.phenomenonBeginTime) {
+              let startTime = calculateEffectiveStartTime(
+                ds.phenomenonBeginTime,
+                ds.phenomenonEndTime,
+                72
+              )
+              return this.getObservationsSince(ds.id, startTime)
+            } else {
+              last72HoursStore.loaded[ds.id] = true
+            }
+          })
+          .filter(Boolean)
+        await Promise.all(observationPromises)
       },
     },
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,12 @@
 export type DataArray = [string, number][]
 
+export interface ObservationRecord {
+  dataArray: DataArray
+  beginTime: string
+  endTime: string
+  loading: boolean
+}
+
 export interface Owner {
   firstName: string
   lastName: string

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,10 +1,15 @@
 export type DataArray = [string, number][]
 
-export interface ObservationRecord {
+export class ObservationRecord {
   dataArray: DataArray
   beginTime: string
-  endTime: string
   loading: boolean
+
+  constructor() {
+    this.dataArray = []
+    this.beginTime = ''
+    this.loading = false
+  }
 }
 
 export interface Owner {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,4 @@
-export interface DataPoint {
-  date: string
-  value: number
-}
-
-export type DataArray = DataPoint[]
+export type DataArray = [string, number][]
 
 export interface Owner {
   firstName: string

--- a/src/utils/FocusContextPlot.ts
+++ b/src/utils/FocusContextPlot.ts
@@ -1,14 +1,14 @@
 import * as Plot from '@observablehq/plot'
 import * as d3 from 'd3'
 
-interface PlotData {
+type DataPoint = {
   date: Date
   value: number
 }
 
 const dispatch = d3.dispatch('timeWindow')
 
-export function focus(data: PlotData[], yAxisLabel: string): SVGSVGElement {
+export function focus(data: DataPoint[], yAxisLabel: string): SVGSVGElement {
   const [minX, maxX] = d3.extent(data, (d) => d.date)
   const [minY, maxY] = d3.extent(data, (d) => d.value)
   const spec = {
@@ -139,7 +139,7 @@ export function focus(data: PlotData[], yAxisLabel: string): SVGSVGElement {
   return wrapper
 }
 
-export function context(data: PlotData[], width: number): SVGSVGElement {
+export function context(data: DataPoint[]): SVGSVGElement {
   const [minY, maxY] = d3.extent(data, (d) => d.value)
 
   const chart = Plot.plot({

--- a/src/utils/observationsUtils.ts
+++ b/src/utils/observationsUtils.ts
@@ -1,0 +1,57 @@
+import { DataArray } from '@/types'
+import { ENDPOINTS } from '@/constants'
+import { api } from '@/utils/api/apiMethods'
+
+export function subtractHours(timestamp: string, hours: number): string {
+  const date = new Date(timestamp)
+  date.setHours(date.getHours() - hours)
+  return date.toISOString()
+}
+
+export async function fetchObservations(
+  id: string,
+  startTime: string,
+  endTime?: string
+) {
+  let allData: DataArray = []
+
+  let nextLink = endTime
+    ? ENDPOINTS.SENSORTHINGS.DATASTREAMS.OBSERVATIONS_BETWEEN_DATES(
+        id,
+        startTime,
+        endTime
+      )
+    : ENDPOINTS.SENSORTHINGS.DATASTREAMS.OBSERVATIONS(id, startTime)
+
+  while (nextLink) {
+    const data = await api.fetch(nextLink)
+    if (data.value && data.value[0] && data.value[0].dataArray) {
+      allData = allData.concat(data.value[0].dataArray)
+    }
+    nextLink = data['@iot.nextLink'] || null
+  }
+
+  return allData
+}
+
+/**
+ * SensorThings will fail if the requested time range is larger than
+ * what's available. This function will check if the requested beginTime
+ * (endTime - hoursBefore) is older than the datastream's phenomenonBeginTime
+ * and return the newer of the two
+ * @return {string} - The effective start time for the time range
+ */
+export function calculateEffectiveStartTime(
+  datastreamBeginTime: string,
+  endTime: string,
+  hoursBefore: number
+): string {
+  let effectiveStartTime = datastreamBeginTime
+  if (hoursBefore > 0) {
+    const calcStart = subtractHours(endTime, hoursBefore)
+    if (new Date(calcStart) > new Date(datastreamBeginTime)) {
+      effectiveStartTime = calcStart
+    }
+  }
+  return effectiveStartTime
+}


### PR DESCRIPTION
There are two main parts to this pull request: 

1. Refactoring the observations stores. I decided it was confusing to have SensorThings return a DataArray, then immediately change it to a javascript object. pinia-plugin-persisted store also serialized objects when it stores them, so the javascript object didn't store very reliable. I opted to store observations as DataArrays just like SensorThings. Then I created an ObservationRecord type which has a beginTime to allow the frontend to request only the time period of observations it doesn't already have. (if we have the most recent 72 hours, don't ask for that data again). I split up the last72hourstore and the observations store so they call the same utility functions but are completely seperate. This will make it easier to switch the sparklines to photos and eventually get rid of the 72hourstore. 
2. Add a progress bar to the time series plot. 

With these changes, the first time you click on a time range filter on the plot, it will display the loading bar. After that, clicking the same filter or shorter (week is shorter than month) shouldn't call the backend, but rather pull the data from the store and display nearly instantly. 
