### PR TITLE
Fix guest routing & JWT expiry (hydroserver2/hydroserver#39)

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -22,28 +22,10 @@ import Navbar from '@/components/base/Navbar.vue'
 import Footer from '@/components/base/Footer.vue'
 import Notifications from '@/components/base/Notifications.vue'
 import { useRoute } from 'vue-router'
-import { useAuthStore } from '@/store/authentication'
-import { onMounted, onUnmounted } from 'vue'
 import { setupRouteGuards } from './router/router'
 
 const route = useRoute()
 setupRouteGuards()
-
-// Check the refresh token every 600,000 milliseconds = 10 minutes
-// Logout if the refresh token is expired
-const authStore = useAuthStore()
-let interval: any
-
-// TODO: this is bad practice. This behavior should be replaced with vue-idle (https://www.npmjs.com/package/idle-vue) and token refresh backend support
-onMounted(() => {
-  interval = setInterval(() => {
-    authStore.checkTokenExpiry()
-  }, 600000)
-})
-
-onUnmounted(() => {
-  clearInterval(interval)
-})
 </script>
 
 <style scoped lang="scss">

--- a/src/store/authentication.ts
+++ b/src/store/authentication.ts
@@ -62,18 +62,15 @@ export const useAuthStore = defineStore({
       }
     },
     isRefreshTokenExpired() {
-      if (!this.refreshToken) return false
-      const decodedToken = jwtDecode(this.refreshToken) as JWTPayload
-      const currentTime = Date.now() / 1000
-      return decodedToken.exp < currentTime
-    },
-    checkTokenExpiry() {
-      if (this.isRefreshTokenExpired()) {
-        this.logout()
-        Notification.toast({
-          message: 'Session expired. Please login',
-          type: 'info',
-        })
+      if (!this.isLoggedIn || !this.refreshToken) return false
+
+      try {
+        const decodedToken = jwtDecode(this.refreshToken) as JWTPayload
+        const currentTime = Date.now() / 1000
+        return decodedToken.exp < currentTime
+      } catch (e) {
+        console.error('Invalid refresh token:', e)
+        return true
       }
     },
     async createUser(user: User) {


### PR DESCRIPTION
The most important fix was adding the check !this.isLoggedIn in the authentication store. This will prevent anonymous users from getting redirected.

I also modified the JWT refresh logic to trigger as a route guard for all pages instead of as a global loop.

While debugging routing, I noticed that the guards were being triggered twice on refresh or the initial page load. This was because setupRouteGuards() was calling the guards the first time on load and then the second time with checkGuardsOnce(). I removed checkGuardsOnce() because the guards already get called on load