### PR TITLE
Increased observations page size to 10,000

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -37,7 +37,7 @@ export const getObservationsEndpoint = (
   startTime: string,
   endTime?: string
 ) => {
-  let url = `${SENSORTHINGS_BASE}/Datastreams('${id}')/Observations?$resultFormat=dataArray&$top=1000`
+  let url = `${SENSORTHINGS_BASE}/Datastreams('${id}')/Observations?$resultFormat=dataArray&$top=10000`
   url += `&$filter=phenomenonTime%20ge%20${startTime}`
   if (endTime) url += `%20and%20phenomenonTime%20lt%20${endTime}`
   return url


### PR DESCRIPTION
The page size for observations requests has been increased from 1,000 to 10,000 to help speed up datastream plotting.