### PR TITLE
Add parallel observation fetching

### DIFF
--- a/src/components/Datastream/DatastreamTable.vue
+++ b/src/components/Datastream/DatastreamTable.vue
@@ -57,7 +57,9 @@
     </template>
 
     <template v-slot:item.last_observation="{ item }">
-      <div v-if="mostRecentObs[item.raw.id]">
+      <div
+        v-if="mostRecentObs[item.raw.id] && (isOwner || item.raw.isDataVisible)"
+      >
         <v-row>
           {{ formatDate(mostRecentObs[item.raw.id][0]) }}
         </v-row>

--- a/src/components/Datastream/FocusContextPlot.vue
+++ b/src/components/Datastream/FocusContextPlot.vue
@@ -113,7 +113,14 @@ async function getStartTime(hours: number) {
 async function drawObservationsSince(hours: number) {
   if (!props.datastream) return
   const startTime = await getStartTime(hours)
-  const obsSince = await getObservationsSince(props.datastream.id, startTime!)
+
+  const isBig = hours <= 0 && props.datastream.valueCount > 100_000
+  const obsSince = await getObservationsSince(
+    props.datastream,
+    startTime!,
+    isBig
+  )
+
   if (obsSince) drawPlot(obsSince)
 }
 

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -28,18 +28,22 @@ const OP_BASE = `${BASE_URL}/data/observed-properties`
 const PL_BASE = `${BASE_URL}/data/processing-levels`
 const RQ_BASE = `${BASE_URL}/data/result-qualifiers`
 const UNIT_BASE = `${BASE_URL}/data/units`
-const SENSORTHINGS_BASE = `${BASE_URL}/sensorthings/v1.1`
+export const SENSORTHINGS_BASE = `${BASE_URL}/sensorthings/v1.1`
 
 export const JWT_REFRESH = `${ACCOUNT_BASE}/jwt/refresh`
 
 export const getObservationsEndpoint = (
   id: string,
+  pageSize: number,
   startTime: string,
-  endTime?: string
+  endTime?: string,
+  skipCount?: number
 ) => {
-  let url = `${SENSORTHINGS_BASE}/Datastreams('${id}')/Observations?$resultFormat=dataArray&$top=100000`
+  let url = `${SENSORTHINGS_BASE}/Datastreams('${id}')/Observations?$resultFormat=dataArray`
+  url += `&$top=${pageSize}`
   url += `&$filter=phenomenonTime%20ge%20${startTime}`
   if (endTime) url += `%20and%20phenomenonTime%20lt%20${endTime}`
+  if (skipCount) url += `&$skip=${skipCount}`
   return url
 }
 

--- a/src/store/observations.ts
+++ b/src/store/observations.ts
@@ -1,7 +1,10 @@
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
-import { ObservationRecord } from '@/types'
-import { fetchObservations } from '@/utils/observationsUtils'
+import { Datastream, ObservationRecord } from '@/types'
+import {
+  fetchObservations,
+  fetchObservationsParallel,
+} from '@/utils/observationsUtils'
 
 export const useObservationStore = defineStore('observations', () => {
   const observations = ref<Record<string, ObservationRecord>>({})
@@ -18,7 +21,12 @@ export const useObservationStore = defineStore('observations', () => {
     }
   }
 
-  const getObservationsSince = async (id: string, beginTime: string) => {
+  const getObservationsSince = async (
+    datastream: Datastream,
+    beginTime: string,
+    useParallel: boolean
+  ) => {
+    const id = datastream.id
     if (!observations.value[id]?.dataArray) {
       observations.value[id] = new ObservationRecord()
     } else {
@@ -38,7 +46,11 @@ export const useObservationStore = defineStore('observations', () => {
     }
 
     observations.value[id].loading = true
-    const fetchedData = await fetchObservations(id, beginTime)
+
+    const fetchedData = useParallel
+      ? await fetchObservationsParallel(datastream, beginTime)
+      : await fetchObservations(id, beginTime)
+
     updateObservations(id, fetchedData, beginTime)
     return observations.value[id].dataArray
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -84,6 +84,7 @@ export class Datastream {
   timeAggregationIntervalUnitsId: string
   dataSourceId?: string
   dataSourceColumn?: string | number
+  valueCount: number
 
   constructor(thingId: string) {
     this.id = ''
@@ -102,6 +103,7 @@ export class Datastream {
     this.timeAggregationInterval = null
     this.timeAggregationIntervalUnitsId = ''
     this.isVisible = true
+    this.valueCount = 0
     this.isDataVisible = true
   }
 }


### PR DESCRIPTION
hydroserver2/hydroserver#81

Added parallel observation fetching. If the use is requesting less than a year of data, then just fetch normally, 100,000 observations per page. Otherwise, if we're getting all the data and datastream.valueCount > 100,000, then fetch in parallel. 

I went with a parallel page size of 50,000 since it was faster than 100,000. I figure the smaller the page size we pick, the faster it will fetch until we run out of threads on the server. If 50,000 is too slow on beta we might want to lower the page size further, watching the server load.