### PR TITLE
98 gaps

### DIFF
--- a/src/components/Datastream/DatastreamTable.vue
+++ b/src/components/Datastream/DatastreamTable.vue
@@ -47,9 +47,8 @@
           </v-dialog>
           <Sparkline
             @click="item.raw.chartOpen = true"
-            :is-stale="isStale(item.raw.phenomenonEndTime)"
             :observations="observations[item.raw.id]"
-            :no-data-value="item.raw.noDataValue"
+            :datastream="item.raw"
           />
         </div>
         <div v-else>No data for this datastream</div>
@@ -155,12 +154,6 @@ function formatDate(dateString: string) {
   return (
     new Date(dateString).toUTCString().split(' ').slice(1, 5).join(' ') + ' UTC'
   )
-}
-
-function isStale(timestamp: string) {
-  let endTime = new Date(timestamp)
-  let seventyTwoHoursAgo = new Date(Date.now() - 72 * 60 * 60 * 1000)
-  return endTime < seventyTwoHoursAgo
 }
 
 function onDeleteDatastream(id: string) {

--- a/src/components/Datastream/FocusContextPlot.vue
+++ b/src/components/Datastream/FocusContextPlot.vue
@@ -33,8 +33,7 @@ import { useObservationStore } from '@/store/observations'
 import { DataArray } from '@/types'
 import {
   calculateEffectiveStartTime,
-  convertToDataObjects,
-  replaceNoDataValues,
+  preProcessData,
 } from '@/utils/observationsUtils'
 import { useObservationsLast72Hours } from '@/store/observations72Hours'
 import { api } from '@/services/api'
@@ -82,9 +81,7 @@ const fetchObservedProperty = api
   })
 
 async function drawPlot(dataArray: DataArray) {
-  // Observable Plot expects an array of objects so convert
-  let data = convertToDataObjects(dataArray)
-  data = replaceNoDataValues(data, props.datastream.noDataValue)
+  let data = preProcessData(dataArray, props.datastream)
 
   if (focusChart.value) {
     const focusSVG = focus(data, yAxisLabel)

--- a/src/components/Sparkline.vue
+++ b/src/components/Sparkline.vue
@@ -7,33 +7,37 @@ import { ref, onMounted } from 'vue'
 import * as Plot from '@observablehq/plot'
 import * as d3 from 'd3'
 import { PropType } from 'vue'
-import { DataArray } from '@/types'
-import {
-  convertToDataObjects,
-  replaceNoDataValues,
-} from '@/utils/observationsUtils'
+import { DataArray, Datastream } from '@/types'
+import { preProcessData } from '@/utils/observationsUtils'
 
 const props = defineProps({
   observations: {
     type: Array as PropType<DataArray>,
     required: true,
   },
-  noDataValue: Number,
-  isStale: Boolean,
+  datastream: {
+    type: Object as PropType<Datastream>,
+    required: true,
+  },
 })
 
 const chart = ref<HTMLDivElement | null>(null)
 
+function isStale(timestamp: string | null | undefined) {
+  if (!timestamp) return true
+  let endTime = new Date(timestamp)
+  let seventyTwoHoursAgo = new Date(Date.now() - 72 * 60 * 60 * 1000)
+  return endTime < seventyTwoHoursAgo
+}
+
 function drawChart() {
   if (!chart.value) return
 
-  let colors = props.isStale
+  let colors = isStale(props.datastream.phenomenonEndTime)
     ? { line: '#9E9E9E', fill: '#F5F5F5' } // Grey and grey-lighten-4
     : { line: '#4CAF50', fill: '#E8F5E9' } // Green and green-lighten-5
 
-  let observations = convertToDataObjects(props.observations)
-  if (props.noDataValue)
-    observations = replaceNoDataValues(observations, props.noDataValue)
+  let observations = preProcessData(props.observations, props.datastream)
 
   const [minY, maxY] = d3.extent(observations, (d) => d.value)
 

--- a/src/composables/useDatastreamForm.ts
+++ b/src/composables/useDatastreamForm.ts
@@ -20,7 +20,7 @@ export function useDatastreamForm(thingId: string, datastreamId: string) {
       processingLevelId: fetchedDS.processingLevelId,
       unitId: fetchedDS.unitId,
       timeAggregationIntervalUnitsId: fetchedDS.timeAggregationIntervalUnitsId,
-      intendedTimeSpacingUnitsId: fetchedDS.intendedTimeSpacingUnitsId,
+      intendedTimeSpacingUnits: fetchedDS.intendedTimeSpacingUnits,
       name: fetchedDS.name,
       description: fetchedDS.description,
       sampledMedium: fetchedDS.sampledMedium,

--- a/src/pages/DatastreamForm.vue
+++ b/src/pages/DatastreamForm.vue
@@ -198,18 +198,18 @@
                 :rules="rules.requiredNumber"
                 type="number"
                 class="mb-4"
-              ></v-text-field>
+              />
 
               <v-autocomplete
                 v-model="datastream.timeAggregationIntervalUnitsId"
-                label="Select time aggregation unit *"
+                label="Time aggregation unit *"
                 :items="timeUnits"
                 item-title="name"
                 item-value="id"
                 :rules="rules.required"
                 no-data-text="No available units"
                 class="pb-1"
-              ></v-autocomplete>
+              />
               <div v-if="isPrimaryOwner">
                 <v-btn-add @click="openAggUnitForm = true">Add New</v-btn-add>
                 <v-dialog v-model="openAggUnitForm" width="60rem">
@@ -233,26 +233,13 @@
               ></v-text-field>
 
               <v-autocomplete
-                v-model="datastream.intendedTimeSpacingUnitsId"
-                label="Select intended time spacing unit"
-                :items="timeUnits"
-                item-title="name"
-                item-value="id"
+                v-model="datastream.intendedTimeSpacingUnits"
+                label="Intended time spacing unit"
+                :items="intendedTimeUnits"
                 no-data-text="No available units"
                 class="pb-1"
                 clearable
-              ></v-autocomplete>
-
-              <div v-if="isPrimaryOwner">
-                <v-btn-add @click="openITUnitForm = true">Add New</v-btn-add>
-                <v-dialog v-model="openITUnitForm" width="60rem">
-                  <UnitFormCard
-                    @created="datastream.intendedTimeSpacingUnitsId = $event"
-                    @close="openITUnitForm = false"
-                    >Add New</UnitFormCard
-                  >
-                </v-dialog>
-              </div>
+              />
             </v-col>
           </v-row>
         </v-card-text>
@@ -265,7 +252,7 @@
             Return to previous page
           </v-btn-cancel>
         </v-col>
-        <v-spacer></v-spacer>
+        <v-spacer />
         <v-col cols="auto">
           <v-btn-primary type="submit">{{
             datastreamId ? 'Update' : 'Save'
@@ -297,9 +284,9 @@ const thingId = route.params.id.toString()
 const datastreamId = route.params.datastreamId?.toString() || ''
 
 const timeUnits = ref<Unit[]>([])
+const intendedTimeUnits = ['seconds', 'minutes', 'hours', 'days']
 const openUnitForm = ref(false)
 const openAggUnitForm = ref(false)
-const openITUnitForm = ref(false)
 
 const isPrimaryOwner = ref(false)
 const showTemplateModal = ref(false)

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -103,7 +103,7 @@ export class Datastream {
   phenomenonBeginTime?: string | null
   phenomenonEndTime?: string | null
   intendedTimeSpacing?: number
-  intendedTimeSpacingUnitsId?: string
+  intendedTimeSpacingUnits?: string | null
   timeAggregationInterval: number | null
   timeAggregationIntervalUnitsId: string
   dataSourceId?: string | null

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -17,6 +17,8 @@ export class ObservationRecord {
   }
 }
 
+export type TimeSpacingUnit = 'seconds' | 'minutes' | 'hours' | 'days'
+
 export interface Owner {
   firstName: string
   lastName: string

--- a/src/utils/observationsUtils.ts
+++ b/src/utils/observationsUtils.ts
@@ -1,4 +1,4 @@
-import { DataArray, DataPoint, Datastream } from '@/types'
+import { DataArray, DataPoint, Datastream, TimeSpacingUnit } from '@/types'
 import { api, getObservationsEndpoint } from '@/services/api'
 
 export function subtractHours(timestamp: string, hours: number): string {
@@ -88,7 +88,7 @@ export function calculateEffectiveStartTime(
   return effectiveStartTime
 }
 
-export function convertToDataObjects(dataArray: DataArray) {
+export function toDataPointArray(dataArray: DataArray) {
   return dataArray.map(([dateString, value]) => ({
     date: new Date(dateString),
     value,
@@ -101,4 +101,60 @@ export function replaceNoDataValues(data: DataPoint[], noDataValue: number) {
     ...d,
     value: d.value === noDataValue ? NaN : d.value,
   }))
+}
+
+export function convertTimeSpacingToMilliseconds(
+  timeSpacing: number,
+  unit: TimeSpacingUnit
+): number {
+  const unitToMilliseconds = {
+    seconds: 1000,
+    minutes: 1000 * 60,
+    hours: 1000 * 60 * 60,
+    days: 1000 * 60 * 60 * 24,
+  }
+
+  return timeSpacing * (unitToMilliseconds[unit] || 0)
+}
+
+function calculateTimeDifference(point1: DataPoint, point2: DataPoint): number {
+  const time1 = new Date(point1.date).getTime()
+  const time2 = new Date(point2.date).getTime()
+
+  return Math.abs(time2 - time1)
+}
+
+export function addNaNForGaps(data: DataPoint[], maxGap: number): DataPoint[] {
+  const modifiedData: DataPoint[] = []
+  data.forEach((point, index) => {
+    modifiedData.push(point)
+    if (index < data.length - 1) {
+      const timeDifference = calculateTimeDifference(point, data[index + 1])
+      if (timeDifference > maxGap) {
+        modifiedData.push({
+          date: new Date(point.date.getTime() + 1),
+          value: NaN,
+        })
+      }
+    }
+  })
+  return modifiedData
+}
+
+export function preProcessData(dataArray: DataArray, datastream: Datastream) {
+  const { noDataValue, intendedTimeSpacing, intendedTimeSpacingUnits } =
+    datastream
+
+  let data = toDataPointArray(dataArray)
+  data = replaceNoDataValues(data, noDataValue)
+
+  if (intendedTimeSpacingUnits && intendedTimeSpacing) {
+    const maxGap = convertTimeSpacingToMilliseconds(
+      intendedTimeSpacing,
+      intendedTimeSpacingUnits as TimeSpacingUnit
+    )
+
+    data = addNaNForGaps(data, maxGap)
+  }
+  return data
 }


### PR DESCRIPTION
Resolves hydroserver2/hydroserver#98

I changed the datastream.intendedTimeSpacingUnit from an ID referencing a Unit to a string option of 'seconds' | 'minutes' | 'hours' | 'days'. This follows the pattern used by DataSources and simplifies how we work with time spacing on the frontend and backend (no need to fetch and filter the user's unit list and have ability to manage custom time units). 

Observable Plot will break a line graph wherever it finds a NaN value in the dataArray. I used this to get rid of the interpolation lines in our graphs by running through the dataset and inserting a NaN value 1 millisecond after a point where the time gap between it and the following point is larger than the intended time spacing value.

The following graph is the miami_no_data_vals.yaml test case that contains both no data values (-9999) and data gaps:

<img width="517" alt="image" src="https://github.com/hydroserver2/hydroserver-webapp-front/assets/83979385/f5b67db5-cdc2-426e-aba8-553949942739">
