### PR TITLE
Add Build-Check job to CI/CD Pipeline

### DIFF
--- a/.github/workflows/CI_CD_pipeline.yaml
+++ b/.github/workflows/CI_CD_pipeline.yaml
@@ -4,8 +4,26 @@ run-name: Running CI/CD Pipeline
 on: [push, pull_request]
 
 jobs:
+  Build-Check:
+    name: Verify Project Compiles
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+      - name: Setup Node 18.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+          cache: npm
+          cache-dependency-path: package-lock.json
+      - name: Install dependencies
+        run: npm ci
+      - name: Build
+        run: npm run build
+
   Run-Tests:
     name: Run Unit Tests
+    needs: Build-Check
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo


### PR DESCRIPTION
hydroserver2/hydroserver#120

I looked at options for pre-commit checks and most of them required installing multiple libraries. I thought that was overkill so this change makes the CI/CD pipeline verify the project compiles before doing anything else. This guarantees the pipeline won't try to deploy code with TypeScript errors in it.  