### PR TITLE
Fetch and remove time series independently

### DIFF
--- a/src/components/VisualizeData/DataVisPopupPlot.vue
+++ b/src/components/VisualizeData/DataVisPopupPlot.vue
@@ -58,7 +58,7 @@ const props = defineProps({
 const emit = defineEmits(['close'])
 
 const option = ref<EChartsOption | undefined>()
-const graphSeriesArray = ref<GraphSeries[]>([])
+const graphSeries = ref<GraphSeries | undefined>()
 const updating = ref(false)
 const selectedTime = ref(72)
 const endTime = ref(props.datastream.phenomenonEndTime!)
@@ -76,13 +76,13 @@ const updateState = async (hours?: number) => {
   selectedTime.value = hours || 72
   beginTime.value = subtractHours(endTime.value, selectedTime.value)
 
-  graphSeriesArray.value = await fetchGraphSeries(
-    [props.datastream],
+  graphSeries.value = await fetchGraphSeries(
+    props.datastream,
     beginTime.value,
     endTime.value
   )
 
-  option.value = createEChartsOption(graphSeriesArray.value, {
+  option.value = createEChartsOption([graphSeries.value], {
     addLegend: false,
     addToolbox: false,
     initializeZoomed: false,

--- a/src/utils/__tests__/observationsUtils.spec.ts
+++ b/src/utils/__tests__/observationsUtils.spec.ts
@@ -1,9 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import {
-  subtractHours,
-  calculateEffectiveStartTime,
-  preProcessData,
-} from '@/utils/observationsUtils'
+import { subtractHours, preProcessData } from '@/utils/observationsUtils'
 import { DataArray, Datastream } from '@/types'
 
 describe('subtractHours', () => {
@@ -12,18 +8,6 @@ describe('subtractHours', () => {
     const hours = 5
     const expected = '2022-01-01T05:00:00.000Z'
     expect(subtractHours(timestamp, hours)).toBe(expected)
-  })
-})
-
-describe('calculateEffectiveStartTime', () => {
-  it('returns the effective start time based on datastream begin time and hours before', () => {
-    const datastreamBeginTime = '2022-01-01T00:00:00Z'
-    const endTime = '2022-01-02T00:00:00Z'
-    const hoursBefore = 12
-    const expected = '2022-01-01T12:00:00.000Z'
-    expect(
-      calculateEffectiveStartTime(datastreamBeginTime, endTime, hoursBefore)
-    ).toBe(expected)
   })
 })
 

--- a/src/utils/observationsUtils.ts
+++ b/src/utils/observationsUtils.ts
@@ -47,28 +47,6 @@ export const fetchObservationsParallel = async (
   }
 }
 
-/**
- * SensorThings will fail if the requested time range is larger than
- * what's available. This function will check if the requested beginTime
- * (endTime - hoursBefore) is older than the datastream's phenomenonBeginTime
- * and return the newer of the two
- * @return {string} - The effective start time for the time range
- */
-export function calculateEffectiveStartTime(
-  datastreamBeginTime: string,
-  endTime: string,
-  hoursBefore: number
-): string {
-  let effectiveStartTime = datastreamBeginTime
-  if (hoursBefore > 0) {
-    const calcStart = subtractHours(endTime, hoursBefore)
-    if (new Date(calcStart) > new Date(datastreamBeginTime)) {
-      effectiveStartTime = calcStart
-    }
-  }
-  return effectiveStartTime
-}
-
 export function toDataPointArray(dataArray: DataArray) {
   return dataArray.map(([dateString, value]) => ({
     date: new Date(dateString),

--- a/src/utils/observationsUtils.ts
+++ b/src/utils/observationsUtils.ts
@@ -7,26 +7,6 @@ export function subtractHours(timestamp: string, hours: number): string {
   return date.toISOString()
 }
 
-export async function fetchObservations(
-  id: string,
-  startTime: string,
-  endTime?: string
-) {
-  let allData: DataArray = []
-  const pageSize = 100_000
-  let nextLink = getObservationsEndpoint(id, pageSize, startTime, endTime)
-
-  while (nextLink) {
-    const data = await api.fetchObservations(nextLink)
-    if (data.value && data.value[0] && data.value[0].dataArray) {
-      allData = allData.concat(data.value[0].dataArray)
-    }
-    nextLink = data['@iot.nextLink'] || null
-  }
-
-  return allData
-}
-
 export const fetchObservationsParallel = async (
   datastream: Datastream,
   startTime: string | null = null,

--- a/src/utils/plotting/graphSeriesUtils.ts
+++ b/src/utils/plotting/graphSeriesUtils.ts
@@ -3,61 +3,52 @@ import { api } from '@/services/api'
 import { Snackbar } from '@/utils/notifications'
 import { useObservationStore } from '@/store/observations'
 import { Datastream, GraphSeries } from '@/types'
-import { EChartsColors } from '@/utils/materialColors'
 
 const { fetchObservationsInRange } = useObservationStore()
 
 export const fetchGraphSeries = async (
-  datastreams: Datastream[],
+  datastream: Datastream,
   start: string,
   end: string
 ) => {
-  const updatedGraphSeries: GraphSeries[] = await Promise.all(
-    datastreams.map(async (ds, index) => {
-      const observationsPromise = fetchObservationsInRange(
-        ds,
-        start,
-        end
-      ).catch((error) => {
-        Snackbar.error('Failed to fetch observations')
-        console.error('Failed to fetch observations:', error)
-        return null
-      })
-      const fetchUnitPromise = api.getUnit(ds.unitId).catch((error) => {
-        console.error('Failed to fetch Unit:', error)
-        return null
-      })
-      const fetchObservedPropertyPromise = api
-        .fetchObservedProperty(ds.observedPropertyId)
-        .catch((error) => {
-          console.error('Failed to fetch ObservedProperty:', error)
-          return null
-        })
-
-      const [observations, unit, observedProperty] = await Promise.all([
-        observationsPromise,
-        fetchUnitPromise,
-        fetchObservedPropertyPromise,
-      ])
-
-      const processedData = preProcessData(observations, ds)
-
-      const yAxisLabel =
-        observedProperty && unit
-          ? `${observedProperty.name} (${unit.symbol})`
-          : 'Unknown'
-
-      const lineColor = EChartsColors[index % EChartsColors.length]
-
-      return {
-        id: ds.id,
-        name: ds.name,
-        data: processedData,
-        yAxisLabel,
-        lineColor,
-      }
+  const observationsPromise = fetchObservationsInRange(
+    datastream,
+    start,
+    end
+  ).catch((error) => {
+    Snackbar.error('Failed to fetch observations')
+    console.error('Failed to fetch observations:', error)
+    return null
+  })
+  const fetchUnitPromise = api.getUnit(datastream.unitId).catch((error) => {
+    console.error('Failed to fetch Unit:', error)
+    return null
+  })
+  const fetchObservedPropertyPromise = api
+    .fetchObservedProperty(datastream.observedPropertyId)
+    .catch((error) => {
+      console.error('Failed to fetch ObservedProperty:', error)
+      return null
     })
-  )
 
-  return updatedGraphSeries
+  const [observations, unit, observedProperty] = await Promise.all([
+    observationsPromise,
+    fetchUnitPromise,
+    fetchObservedPropertyPromise,
+  ])
+
+  const processedData = preProcessData(observations, datastream)
+
+  const yAxisLabel =
+    observedProperty && unit
+      ? `${observedProperty.name} (${unit.symbol})`
+      : 'Unknown'
+
+  return {
+    id: datastream.id,
+    name: datastream.name,
+    data: processedData,
+    yAxisLabel,
+    lineColor: '#5571c7', // default to blue,
+  } as GraphSeries
 }


### PR DESCRIPTION
hydroserver2/hydroserver#143

I made it so each dataset is fetched and removed independently. That actually works just fine without an AbortController since the observations pinia store won't request information from the db if it had already requested that information once. After the observations arrive, the store is updated and through the reactivity system, so is everything else. 

The only reason we'd need an AbortController is if someone is on particularly bad wifi and they're navigating around the website particularly fast. I think for now we're going to be fine without one. 

If we do need an AbortController at some point, I'm thinking a good way to get it working is to add a pinia store to hold the controllers. Then have the service layer check for a controller that matches the current url in the requestInterceptor and add it to the fetch request if there is one. We could then have the components that need a controller import the store and abort on command as well as abort everything in the store when the user navigates to a new route.